### PR TITLE
Speed up WordPiece tokenization on ASCII text (~20%)

### DIFF
--- a/wordpiece.go
+++ b/wordpiece.go
@@ -31,10 +31,25 @@ type wordPieceConfig struct {
 // token are dropped, matching model2vec, which filters unknown tokens out
 // before averaging embeddings.
 type wordPieceTokenizer struct {
-	vocab                map[string]int
+	vocab map[string]int
+	// singleByte caches the vocab IDs of single-ASCII-byte tokens (-1 when
+	// absent), so the isolated punctuation words the pre-tokenizer produces
+	// skip the map lookup.
+	singleByte           [128]int32
 	unkID                int // -1 if the vocabulary has no unknown token
 	maxInputCharsPerWord int
 	normalizer           bertNormalizer
+}
+
+// singleByteIDs builds the singleByte cache from a vocabulary.
+func singleByteIDs(vocab map[string]int) (t [128]int32) {
+	for b := range t {
+		t[b] = -1
+		if id, ok := vocab[string(rune(b))]; ok {
+			t[b] = int32(id)
+		}
+	}
+	return t
 }
 
 // newWordPieceTokenizer builds a wordPieceTokenizer from a parsed
@@ -64,6 +79,7 @@ func newWordPieceTokenizer(file tokenizerFile) (*wordPieceTokenizer, error) {
 
 	return &wordPieceTokenizer{
 		vocab:                cfg.Model.Vocab,
+		singleByte:           singleByteIDs(cfg.Model.Vocab),
 		unkID:                unkID,
 		maxInputCharsPerWord: maxInputCharsPerWord,
 		normalizer:           *bertNormalizerFromConfig(cfg),
@@ -180,6 +196,13 @@ func (t *wordPieceTokenizer) word2tok(dst []int, word string) ([]int, error) {
 	// Rune count never exceeds byte length, so words short enough in bytes
 	// skip the counting scan entirely
 	if len(word) > t.maxInputCharsPerWord && utf8.RuneCountInString(word) > t.maxInputCharsPerWord {
+		return t.dropUnknown(dst, mark, word)
+	}
+
+	if len(word) == 1 && word[0] < utf8.RuneSelf {
+		if id := t.singleByte[word[0]]; id >= 0 {
+			return append(dst, int(id)), nil
+		}
 		return t.dropUnknown(dst, mark, word)
 	}
 

--- a/wordpiece.go
+++ b/wordpiece.go
@@ -177,7 +177,9 @@ func preTokenize(sentence string) []string {
 func (t *wordPieceTokenizer) word2tok(dst []int, word string) ([]int, error) {
 	mark := len(dst)
 
-	if utf8.RuneCountInString(word) > t.maxInputCharsPerWord {
+	// Rune count never exceeds byte length, so words short enough in bytes
+	// skip the counting scan entirely
+	if len(word) > t.maxInputCharsPerWord && utf8.RuneCountInString(word) > t.maxInputCharsPerWord {
 		return t.dropUnknown(dst, mark, word)
 	}
 

--- a/wordpiece.go
+++ b/wordpiece.go
@@ -94,31 +94,72 @@ func isBertPunctuation(r rune) bool {
 	return unicode.IsPunct(r)
 }
 
+// ASCII byte classes for preTokenize's fast path.
+const (
+	asciiWord byte = iota
+	asciiSpace
+	asciiPunct
+)
+
+// asciiClass classifies each ASCII byte the way the rune-level predicates
+// below classify it: unicode.IsSpace and isBertPunctuation agree with this
+// table on every value under 0x80.
+var asciiClass = func() (t [128]byte) {
+	for b := range t {
+		switch {
+		case isASCIISpace(byte(b)):
+			t[b] = asciiSpace
+		case (b >= '!' && b <= '/') || (b >= ':' && b <= '@') || (b >= '[' && b <= '`') || (b >= '{' && b <= '~'):
+			t[b] = asciiPunct
+		}
+	}
+	return t
+}()
+
 // preTokenize splits normalized text like HuggingFace's BertPreTokenizer:
 // split on whitespace (removed), then isolate each punctuation character as
 // its own word. The returned words are zero-copy substrings of sentence.
+// ASCII bytes — the entire input for most POTION models, whose normalizer
+// lowercases to ASCII-heavy text — classify through a table without rune
+// decoding; only bytes >= 0x80 take the Unicode path.
 func preTokenize(sentence string) []string {
 	words := make([]string, 0, len(sentence)/4)
 	start := -1
 
-	for i, r := range sentence {
-		switch {
-		case unicode.IsSpace(r):
+	for i := 0; i < len(sentence); {
+		var class byte
+		size := 1
+		if b := sentence[i]; b < utf8.RuneSelf {
+			class = asciiClass[b]
+		} else {
+			var r rune
+			r, size = utf8.DecodeRuneInString(sentence[i:])
+			switch {
+			case unicode.IsSpace(r):
+				class = asciiSpace
+			case isBertPunctuation(r):
+				class = asciiPunct
+			}
+		}
+
+		switch class {
+		case asciiSpace:
 			if start >= 0 {
 				words = append(words, sentence[start:i])
 				start = -1
 			}
-		case isBertPunctuation(r):
+		case asciiPunct:
 			if start >= 0 {
 				words = append(words, sentence[start:i])
 				start = -1
 			}
-			words = append(words, sentence[i:i+utf8.RuneLen(r)])
+			words = append(words, sentence[i:i+size])
 		default:
 			if start < 0 {
 				start = i
 			}
 		}
+		i += size
 	}
 	if start >= 0 {
 		words = append(words, sentence[start:])

--- a/wordpiece_test.go
+++ b/wordpiece_test.go
@@ -39,6 +39,16 @@ func TestPreTokenize(t *testing.T) {
 		// Non-punctuation symbols stay attached
 		{"a€b", []string{"a€b"}},
 		{"...", []string{".", ".", "."}},
+		// Non-ASCII whitespace splits words like ASCII space does
+		{"a b", []string{"a", "b"}},
+		{"a b", []string{"a", "b"}},
+		{"tab\tsep", []string{"tab", "sep"}},
+		// Multibyte runes inside and at the edges of words
+		{"café tea", []string{"café", "tea"}},
+		{"—start", []string{"—", "start"}},
+		{"end—", []string{"end", "—"}},
+		{"日本語", []string{"日本語"}},
+		{"mixé!", []string{"mixé", "!"}},
 	}
 
 	for _, tc := range testCases {

--- a/wordpiece_test.go
+++ b/wordpiece_test.go
@@ -11,6 +11,7 @@ import (
 func newTestWordPiece(vocab map[string]int, unkID, maxChars int) *wordPieceTokenizer {
 	return &wordPieceTokenizer{
 		vocab:                vocab,
+		singleByte:           singleByteIDs(vocab),
 		unkID:                unkID,
 		maxInputCharsPerWord: maxChars,
 		normalizer:           *defaultBertNormalizer(),
@@ -89,6 +90,8 @@ func TestWordPieceTokenize(t *testing.T) {
 		// A word with no full tokenization maps to [UNK], which is
 		// dropped like model2vec does
 		{"unknown word dropped", "hello xyzzy world", []int{1, 2}},
+		{"unknown single char dropped", "hello & world", []int{1, 2}},
+		{"unknown single letter dropped", "hello z world", []int{1, 2}},
 		// Partial subword matches must not leak when the tail fails
 		{"partial match dropped whole", "hello unaffordable world", []int{1, 2}},
 		{"only unknown", "xyzzy", []int{}},

--- a/wordpiece_test.go
+++ b/wordpiece_test.go
@@ -130,6 +130,17 @@ func TestWordPieceMaxInputChars(t *testing.T) {
 	if want := []int{1, 2, 3}; !reflect.DeepEqual(got, want) {
 		t.Errorf("tokenize = %v, want %v", got, want)
 	}
+
+	// The limit counts runes, not bytes: "ααααα" is 10 bytes but 5 runes,
+	// so it must survive a limit of 5
+	tok = newTestWordPiece(map[string]int{"[UNK]": 0, "αα": 1, "##ααα": 2}, 0, 5)
+	got, err = tok.tokenize("ααααα")
+	if err != nil {
+		t.Fatalf("tokenize: %v", err)
+	}
+	if want := []int{1, 2}; !reflect.DeepEqual(got, want) {
+		t.Errorf("tokenize = %v, want %v", got, want)
+	}
 }
 
 func TestWordPieceNoUnknownToken(t *testing.T) {


### PR DESCRIPTION
## Summary

Profiling `BenchmarkEncodeBigText` (BASE2M) showed `Encode` is dominated by tokenization rather than pooling. Three behavior-preserving fast paths, one commit each:

- **ASCII fast path in `preTokenize`**: classify ASCII bytes through a precomputed 128-entry table instead of decoding runes and calling `unicode.IsSpace`/`isBertPunctuation`; only bytes >= 0x80 take the Unicode path. (+17%)
- **Skip rune counting for short words in `word2tok`**: rune count never exceeds byte length, so words within `maxInputCharsPerWord` bytes skip the counting scan. (~2%, confirmed by profile rather than e2e noise)
- **Single-byte token cache**: the pre-tokenizer isolates every punctuation character as its own one-byte word; resolve those through a `[128]int32` table built at construction instead of hashing into the vocab map. (+3%, interleaved A/B)

Combined on an M3 Max (high power, interleaved runs for the last commit): **~60 -> ~72 MB/s** on BASE2M over big.txt. Gains apply to ASCII input on WordPiece models; Unicode-heavy text falls back to the previous per-rune path, and the Unigram tokenizer (MULTILINGUAL128M) is untouched.

## Test plan

- [x] New characterization tests added before each change and verified green against the old implementation: non-ASCII whitespace, multibyte runes at word edges, mixed ASCII/Unicode words, byte-vs-rune length at the `maxInputCharsPerWord` limit, single-char vocab misses
- [x] Full suite passes (90 tests; `TestLoadAndEncode` skipped locally as `validation/samples/` is not generated in this checkout)
- [x] `BenchmarkEncodeBigText` before/after on BASE2M